### PR TITLE
Make loginWithPost public needed to login from outside script

### DIFF
--- a/classes/PHPLogin.php
+++ b/classes/PHPLogin.php
@@ -253,7 +253,7 @@ class PHPLogin{
    * Logs in via the Cookie
    * @return bool success state of cookie login
    */
-  private function loginWithCookieData() {
+  public function loginWithCookieData() {
     if (isset($_COOKIE['rememberme'])) {
       // extract data from the cookie
       list ($user_id, $token, $hash) = explode(':', $_COOKIE['rememberme']);
@@ -298,7 +298,7 @@ class PHPLogin{
    * @param $user_password
    * @param $user_rememberme
    */
-  private function loginWithPostData($user_name, $user_password, $user_rememberme)
+  public function loginWithPostData($user_name, $user_password, $user_rememberme)
   {
     if (empty($user_name)) {
       $this->errors[] = MESSAGE_USERNAME_EMPTY;


### PR DESCRIPTION
Also cookie login public, in case the project owner wants to detect cookies and automatically log in from outside the included forms, e.g. using Bootstrap modals vs. an entire page just for either the login or register functions
